### PR TITLE
Feature/allow GitHub user login without email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,8 +32,8 @@ class User < ActiveRecord::Base
   def self.from_omniauth(auth)
     email = auth.info.email.nil? ? auth.extra.raw_info.email : auth.info.email
     login = auth.extra.raw_info.login
-    if !login.nil? and !email.nil?
-    	User.where(provider: auth.provider, provider_username: login, email: email).first_or_create do |user|
+    if !login.nil?
+    	User.where(provider: auth.provider, provider_username: login).first_or_create do |user|
     		user.provider = auth.provider
     		user.uid = auth.uid
     		user.email = email
@@ -41,6 +41,10 @@ class User < ActiveRecord::Base
     		user.password = Devise.friendly_token[0,20]
     	end
     end
+  end
+
+  def email_required?
+    false
   end
 
   def is_admin?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ActiveRecord::Base
   def self.from_omniauth(auth)
     email = auth.info.email.nil? ? auth.extra.raw_info.email : auth.info.email
     login = auth.extra.raw_info.login
-    if !login.nil?
+    unless login.nil?
     	User.where(provider: auth.provider, provider_username: login).first_or_create do |user|
     		user.provider = auth.provider
     		user.uid = auth.uid

--- a/db/migrate/20161019233104_devise_create_users.rb
+++ b/db/migrate/20161019233104_devise_create_users.rb
@@ -3,7 +3,7 @@ class DeviseCreateUsers < ActiveRecord::Migration
     create_table :users do |t|
       ## Database authenticatable
       t.string :provider_username,  null: false, default: ""
-      t.string :email,              null: false, default: ""
+      t.string :email,              null: true, default: ""
       t.string :encrypted_password, null: false, default: ""
 
       ## Recoverable

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 20161020040440) do
 
   create_table "users", force: :cascade do |t|
     t.string   "provider_username",      default: "",      null: false
-    t.string   "email",                  default: "",      null: false
+    t.string   "email",                  default: ""
     t.string   "encrypted_password",     default: "",      null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"

--- a/features/github_user_login.feature
+++ b/features/github_user_login.feature
@@ -3,9 +3,16 @@ Feature: GitHub User Login
 	As a user of projectscope, I should be able to login
 	if I have an valid github account
 
-Scenario: github user login
+Scenario: github user login with email
 	Given I am on the login page
 	And I have a valid github account with email "test-coach@test.com" username "test-coach"
+	When I follow "Sign in with GitHub"
+	Then I should be on the home page
+	And I should see "Signed in successfully."
+
+Scenario: github user login without email
+	Given I am on the login page
+	And I have a valid github account with email "" username "test-coach"
 	When I follow "Sign in with GitHub"
 	Then I should be on the home page
 	And I should see "Signed in successfully."

--- a/features/step_definitions/project_steps.rb
+++ b/features/step_definitions/project_steps.rb
@@ -56,11 +56,21 @@ Given(/^A project update job has been run$/) do
 end
 
 And(/^I am logged in$/) do
-  steps %Q{
-    Given I am on the login page
-    And I have a valid github account with email "test-coach@test.com" username "test-coach"
-    And I follow "Sign in with GitHub"
-  }
+  visit path_to("the login page")
+  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+    {
+      :uid => '12345',
+      :info => {
+        :email => "test-coach@test.com"
+      },
+      :extra => {
+        :raw_info => {
+          :email => "test-coach@test.com",
+          :login => "test-coach"
+        }
+      }
+    })
+  click_link "Sign in with GitHub"
   sleep(1)
 end
 

--- a/features/step_definitions/user_login_steps.rb
+++ b/features/step_definitions/user_login_steps.rb
@@ -1,4 +1,5 @@
 When /^I have a valid github account with email "(.*)" username "(.*)"/ do |email, username|
+	email = nil if email == ""
 	OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
 		{
 	    :uid => '12345',


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/133386617

Feature:
1. allowed github user login without email (only github username is needed)