### PR TITLE
Add delayed_job gem to handle resample.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem 'omniauth-github', github: 'intridea/omniauth-github'
 
 gem 'bootstrap-sass', '~> 3.3.6'
 
+gem 'delayed_job_active_record'
+
 group :development, :test do
   gem 'sqlite3'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,11 @@ GEM
     debug_inspector (0.0.2)
     declarative (0.0.8)
       uber (>= 0.0.15)
+    delayed_job (4.1.2)
+      activesupport (>= 3.0, < 5.1)
+    delayed_job_active_record (4.1.1)
+      activerecord (>= 3.0, < 5.1)
+      delayed_job (>= 3.0, < 5)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (4.2.0)
@@ -403,6 +408,7 @@ DEPENDENCIES
   cucumber-rails
   cucumber-rails-training-wheels
   database_cleaner
+  delayed_job_active_record
   devise
   dotenv-rails
   factory_girl_rails

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,5 @@
 class ProjectsController < ApplicationController
-  before_action :set_project, only: [:show, :edit, :update, :destroy]
+  before_action :set_project, only: [:show, :edit, :update, :destroy, :resample]
   before_action :authenticate_user!
 
   # GET /projects
@@ -71,6 +71,12 @@ class ProjectsController < ApplicationController
       format.html { redirect_to projects_url, notice: 'Project was successfully destroyed.' }
       format.json { head :no_content }
     end
+  end
+
+  # PUT /projects/1/resample
+  def resample
+    @project.resample_all_metrics
+    redirect_to projects_url, notice: 'Task has been added. Please refresh later to see the latest data.'
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -54,5 +54,6 @@ class Project < ActiveRecord::Base
       end
     end
   end
+  handle_asynchronously :resample_metric
 
 end

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -2,12 +2,13 @@
 
 %h1 Project List
 
-%table
+%table{:class => 'table'}
   %thead
     %tr
       %th{:class => @class}= link_to "Project Name", projects_path(:type => "project_name"), :id => "project_name"
       - @metric_names.each do |metric_name|
         %th{:class => @class}= link_to metric_name, projects_path(:type => metric_name), :id => metric_name
+      %th Resample
   
   %tbody
     - @projects.each do |project|
@@ -18,6 +19,8 @@
             %td{:id => "#{project.name}_#{sample.try(:metric_name)}_metric"}
               = '%.2f'.try(:%,sample.try(:score) || 0.0)
               #{raw sample.try(:image)}
+        %td
+          = link_to 'Resample', resample_project_path(project.id), method: :put, :class => 'btn btn-primary'
 
 %br/
 

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,6 @@ module ProjectscopeMvp
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
   resources :users, :only => [:show, :update], :path => "u"
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }, :skip => [:password]
   
-  resources :projects
+  resources :projects do
+    member do
+      put 'resample'
+    end
+  end
   root 'projects#index'
 end

--- a/db/migrate/20161120221720_create_delayed_jobs.rb
+++ b/db/migrate/20161120221720_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161101210440) do
+ActiveRecord::Schema.define(version: 20161120221720) do
 
   create_table "configs", force: :cascade do |t|
     t.integer  "project_id"
@@ -23,6 +23,22 @@ ActiveRecord::Schema.define(version: 20161101210440) do
   end
 
   add_index "configs", ["project_id"], name: "index_configs_on_project_id"
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer  "priority",   default: 0, null: false
+    t.integer  "attempts",   default: 0, null: false
+    t.text     "handler",                null: false
+    t.text     "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by"
+    t.string   "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority"
 
   create_table "metric_samples", force: :cascade do |t|
     t.integer  "project_id"


### PR DESCRIPTION
- Add delayed_job gem.
- Handle resample asynchronously by delayed_job worker.
- Add a resample method to projects.
- Update projects index page.

I added delayed_job gem to handle asynchronous jobs. Including this gem will provide necessary infrastructure to handle more complex functionalities (such as grading as I'm about to work on). Adding this gem requires enabling delayed_job worker on heroku side, which is free to use.

I added a resample button in the index page so that TAs can get instant feedback.

There is no test.